### PR TITLE
Gruntfile rewrite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -396,8 +396,6 @@ module.exports = function (grunt) {
   grunt.registerTask('build', [
     'clean:dist',                 //Wipes out the tmp and dist folders to start fresh.
 
-    'wiredep',                    //Automatically includes dependencies into index.html.
-
     'useminPrepare',              //Generates a configuration file for concat, uglify, and cssmin based on index.html.
                                   // <!-- build:js(.)  --> & <!-- build:css(.) --> comment blocks denote this.
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,9 +160,9 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
+          cwd: '<%= yeoman.dist %>/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          dest: '<%= yeoman.dist %>/styles/'
         }]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,10 +29,6 @@ module.exports = function (grunt) {
 
     // Watches files for changes and runs tasks based on the changed files
     watch: {
-      bower: {
-        files: ['bower.json'],
-        tasks: ['wiredep']
-      },
       js: {
         files: ['<%= yeoman.app %>/scripts/{,*/}*.js'],
         tasks: ['newer:jshint:all'],
@@ -168,30 +164,6 @@ module.exports = function (grunt) {
           src: '{,*/}*.css',
           dest: '.tmp/styles/'
         }]
-      }
-    },
-
-    // Automatically inject Bower components into the app
-    wiredep: {
-      app: {
-        src: ['<%= yeoman.app %>/index.html'],
-        ignorePath:  /\.\.\//
-      },
-      test: {
-        devDependencies: true,
-        src: '<%= karma.unit.configFile %>',
-        ignorePath:  /\.\.\//,
-        fileTypes:{
-          js: {
-            block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
-              detect: {
-                js: /'(.*\.js)'/gi
-              },
-              replace: {
-                js: '\'{{filePath}}\','
-              }
-            }
-          }
       }
     },
 
@@ -373,7 +345,6 @@ module.exports = function (grunt) {
 
     grunt.task.run([
       'clean:server',
-      'wiredep',
       'autoprefixer:server',
       'connect:livereload',
       'watch'
@@ -387,7 +358,6 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test', [
     'clean:server',
-    'wiredep',
     'autoprefixer',
     'connect:test',
     'karma'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -215,18 +215,18 @@ module.exports = function (grunt) {
       }
     },
 
-    // uglify: {
-    //   dist: {
-    //     files: {
-    //       '<%= yeoman.dist %>/scripts/scripts.js': [
-    //         '<%= yeoman.dist %>/scripts/scripts.js'
-    //       ]
-    //     }
-    //   }
-    // },
-    // concat: {
-    //   dist: {}
-    // },
+    uglify: {
+      dist: {
+        files: {
+          '<%= yeoman.dist %>/bower_components/skel/src/skel.js': '<%= yeoman.dist %>/bower_components/skel/src/skel.js',
+          '<%= yeoman.dist %>/bower_components/skel-layers/src/skel-layers.js': '<%= yeoman.dist %>/bower_components/skel-layers/src/skel-layers.js',
+          '<%= yeoman.dist %>/bower_components/angular-route/angular-route.js': '<%= yeoman.dist %>/bower_components/angular-route/angular-route.js',
+        }
+      }
+    },
+    concat: {
+      dist: {}
+    },
 
     imagemin: {
       dist: {
@@ -286,6 +286,19 @@ module.exports = function (grunt) {
       dist: {
         html: ['<%= yeoman.dist %>/*.html']
       }
+    },
+
+    bowercopy: {
+      options: {
+                destPrefix: '<%= yeoman.dist %>/bower_components'
+            },
+        dist: {
+            files: {
+                'skel/src/skel.js': 'skel/src/skel.js',
+                'skel-layers/src/skel-layers.js': 'skel-layers/src/skel-layers.js',
+                'angular-route/angular-route.js': 'angular-route/angular-route.js'
+            }
+        }
     },
 
     // Copies remaining files to places other tasks can use
@@ -375,14 +388,15 @@ module.exports = function (grunt) {
 
     'copy:dist',                  //Copy all files for deployment to the dist folder.
 
-    'copy:fonts',                  //Copy all files for deployment to the dist folder.
+    'bowercopy:dist',
+
+    'copy:fonts',                 //Copy all files for deployment to the dist folder.
 
     'autoprefixer',               //Adds missing browser prefixes to css files.
                                   //leaves newly prefixed files in .tmp/styles
 
     'concat',                     //Concats all javascript and css sourcefiles together.
                                   //scripts.js is made from the app's js files.
-                                  //vendor.js is likewise made from dependencies js files.
                                   //main.css is made from the .tmp/styles/main.css
                                   //vendor.css is likewise made from dependencies css files.
 

--- a/app/index.html
+++ b/app/index.html
@@ -55,10 +55,11 @@
        ga('send', 'pageview');
     </script>
 
-    <!-- build:js(.) scripts/vendor.js -->
-    <!-- bower:js -->
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
+
+    <!-- build:js(.) scripts/vendor.js -->
+    <!-- bower:js -->
     <script src="bower_components/skel/src/skel.js"></script>
     <script src="bower_components/skel-layers/src/skel-layers.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -60,11 +60,11 @@
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
 
-    <!-- build:js(.) scripts/vendor.js -->
+
     <script src="bower_components/skel/src/skel.js"></script>
     <script src="bower_components/skel-layers/src/skel-layers.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>
-    <!-- endbuild -->
+
 
     <!-- build:js({.tmp,app}) scripts/scripts.js -->
     <script src="scripts/init.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
     <!-- endbuild -->
 
   </head>
-  <body ng-app="websiteApp" ng-controller="MainCtrl" class="homepage">
+  <body style="display:none;" ng-app="websiteApp" ng-controller="MainCtrl" class="homepage">
     <!--[if lt IE 7]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->

--- a/app/index.html
+++ b/app/index.html
@@ -11,12 +11,13 @@
       web development, SCADA, mobile applications, apps, programmers,
       technical, ios, android, developers, recruit, consultant">
     <meta name="viewport" content="width=device-width">
+
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+
     <!-- build:css(.) styles/vendor.css -->
-    <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
-    <!-- endbower -->
     <!-- endbuild -->
+
   </head>
   <body ng-app="websiteApp" ng-controller="MainCtrl" class="homepage">
     <!--[if lt IE 7]>
@@ -55,15 +56,14 @@
        ga('send', 'pageview');
     </script>
 
+    <!-- CDNify dependencies go here. -->
     <script src="bower_components/jquery/dist/jquery.js"></script>
     <script src="bower_components/angular/angular.js"></script>
 
     <!-- build:js(.) scripts/vendor.js -->
-    <!-- bower:js -->
     <script src="bower_components/skel/src/skel.js"></script>
     <script src="bower_components/skel-layers/src/skel-layers.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>
-    <!-- endbower -->
     <!-- endbuild -->
 
     <!-- build:js({.tmp,app}) scripts/scripts.js -->

--- a/app/styles/style.css
+++ b/app/styles/style.css
@@ -13,6 +13,7 @@
 
   body
   {
+    display: block !important;
     background: #f2f5f3;
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "grunt-ng-annotate": "^0.9.2",
     "grunt-svgmin": "^2.0.0",
     "grunt-usemin": "^3.0.0",
-    "grunt-wiredep": "^2.0.0",
     "jasmine-core": "^2.2.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.31",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^2.0.0",
+    "grunt-bowercopy": "^1.2.0",
     "grunt-concurrent": "^1.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
@kevinmershon For your review.

In order to get performance increases, we had to sacrifice some automation in our build tools.

Wiredep is gone so it would not automatically add angular and jquery references.
CDNify now can target those explicit includes and replace them with google URLs.
Other dependencies are no longer condensed into a vendor.js and instead load concurrently with bowercopy. Custom uglify rules were added to minify them.

This means that if we add dependencies, we now have to update urls for them in three places. The include, the bower copy, and the uglify config blocks.

However, it should be said that none of that helped the artifact popping issue. If we want these back, all we have to do is add only 9215ad058003fe9c56086cd09f2bd0e4649f3e1a and ignore the rest. The difference is about 500ms of load time.
