### PR TITLE
Updated references to skel repos.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,10 +4,10 @@
   "dependencies": {
     "angular": "^1.3.0",
     "font-awesome": "~4.3.0",
-    "skel": "~2.2.1",
-    "skel-layers": "~2.0.2",
     "jquery": "~2.1.3",
-    "angular-route": "~1.3.15"
+    "angular-route": "~1.3.15",
+    "skel": "n33/skel.old#~2.2.1",
+    "skel-layers": "fabfuel/skel-layers#~2.0.2"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"


### PR DESCRIPTION
@kevinmershon Instead of updating to skel 3.0.0, the reference was changed to a new location of the older skel version as well as a new host for skel-layers. This way we can maintain the function of skel-layers for the site.
